### PR TITLE
feat: block SSM document public sharing

### DIFF
--- a/modules/account_level/main.tf
+++ b/modules/account_level/main.tf
@@ -46,3 +46,8 @@ module "aws_support_role" {
   poweruser_role_policy_arns = ["arn:aws:iam::aws:policy/AWSSupportAccess"]
   create_poweruser_role      = true
 }
+
+resource "aws_ssm_service_setting" "block_public_sharing" {
+  setting_id    = "/ssm/documents/console/public-sharing-permission"
+  setting_value = "Disable"
+}

--- a/modules/account_level/main.tf
+++ b/modules/account_level/main.tf
@@ -47,7 +47,3 @@ module "aws_support_role" {
   create_poweruser_role      = true
 }
 
-resource "aws_ssm_service_setting" "block_public_sharing" {
-  setting_id    = "/ssm/documents/console/public-sharing-permission"
-  setting_value = "Disable"
-}

--- a/modules/region_level/main.tf
+++ b/modules/region_level/main.tf
@@ -52,3 +52,8 @@ module "cmk_access_logs_bucket" {
 
   tags = merge(var.cmk_access_logs_bucket_config.tags, var.tags)
 }
+
+resource "aws_ssm_service_setting" "block_public_sharing" {
+  setting_id    = "/ssm/documents/console/public-sharing-permission"
+  setting_value = "Disable"
+}

--- a/modules/region_level/main.tf
+++ b/modules/region_level/main.tf
@@ -54,6 +54,7 @@ module "cmk_access_logs_bucket" {
 }
 
 resource "aws_ssm_service_setting" "block_public_sharing" {
+  count         = var.create_ssm_block_public_sharing ? 1 : 0
   setting_id    = "/ssm/documents/console/public-sharing-permission"
   setting_value = "Disable"
 }

--- a/modules/region_level/variables.tf
+++ b/modules/region_level/variables.tf
@@ -208,6 +208,16 @@ variable "s3_tf_state_bucket_server_side_encryption_configuration" {
 
 # ------------------------------------------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------------------------------------------
+# SSM regional baseline
+
+variable "create_ssm_block_public_sharing" {
+  description = "Whether to block public sharing of SSM documents in the region."
+  type        = bool
+  default     = true
+}
+
+# ------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------------------------------------
 # EBS regional baseline
 
 variable "create_ebs_snapshot_block_public_access" {


### PR DESCRIPTION
Adds an `aws_ssm_service_setting` resource to disable public sharing of SSM documents at the account level.