### PR TITLE
feat(region_level): add AWS Config daily recording mode support

### DIFF
--- a/modules/region_level/AWS_CONFIG_DAILY_RECORDING.md
+++ b/modules/region_level/AWS_CONFIG_DAILY_RECORDING.md
@@ -1,0 +1,52 @@
+# AWS Config Daily Recording
+
+## Overview
+
+AWS Control Tower enables AWS Config with **CONTINUOUS** recording by default on all enrolled accounts. This records every configuration change as it happens, which provides real-time visibility but can generate significant costs at scale.
+
+This module allows you to switch the recording mode to **DAILY**, where Config captures a snapshot of your resource configurations once every 24 hours instead of on every change. This reduces AWS Config costs while still maintaining compliance visibility for most use cases.
+
+## Usage
+in the aft-account-customizations repo , in the modules/region/baseline.tf path add the following variable 
+```hcl
+module "baseline" {
+  source = "fivexl/account-baseline/aws//modules/region_level"
+
+  manage_aws_config_recording_mode = true
+}
+```
+
+That's it. The module will:
+
+1. Automatically import the existing Config recorder (named `default`) into Terraform state
+2. Look up the existing IAM role (`aws-controltower-ConfigRecorderRole`) created by Control Tower
+3. Update the recording mode from `CONTINUOUS` to `DAILY`
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `manage_aws_config_recording_mode` | `false` | Set to `true` to manage the recording mode |
+| `aws_config_recording_frequency` | `"DAILY"` | Recording frequency: `CONTINUOUS` or `DAILY` |
+| `aws_config_recorder_name` | `"default"` | Name of the existing recorder |
+| `aws_config_recorder_role_arn` | `""` | Override the role ARN (auto-detected if empty) |
+| `aws_config_recorder_role_name` | `"aws-controltower-ConfigRecorderRole"` | Role name for auto-detection |
+| `aws_config_recording_group` | `{ all_supported = true, include_global_resource_types = false }` | Recording group settings |
+
+## How It Works
+
+- **Import block**: Uses Terraform's native `import` block (requires Terraform >= 1.5) to adopt the existing Config recorder into state on first apply. No manual `terraform import` command needed.
+- **Role detection**: Looks up the Control Tower-created IAM role by name via a `data "aws_iam_role"` data source. You can skip this by providing `aws_config_recorder_role_arn` directly.
+- **Idempotent**: If you deploy this to an account where Config is already set to DAILY, Terraform will show no changes.
+
+## Important Notes
+
+- **Control Tower compatibility**: This only modifies the recording frequency. It does not touch the delivery channel, IAM role permissions, or recorder status (enabled/disabled). Control Tower continues to manage those.
+- **Multi-region**: You need to enable this in each region module instance. In a typical AFT setup where you call the region_level module for each region, add `manage_aws_config_recording_mode = true` to each call.
+- **Reverting**: Set `aws_config_recording_frequency = "CONTINUOUS"` to switch back without removing the resource from state.
+
+## Cost Impact
+
+DAILY recording can significantly reduce AWS Config costs for accounts with high rates of configuration changes. The exact savings depend on your workload, but accounts with frequent autoscaling, CI/CD deployments, or short-lived resources benefit the most.
+
+Note that DAILY recording means configuration drift or unauthorized changes won't be recorded until the next daily snapshot. If real-time detection is critical for specific resource types, consider keeping those on CONTINUOUS using Config's recording mode overrides (not currently exposed by this module but can be added).

--- a/modules/region_level/config.tf
+++ b/modules/region_level/config.tf
@@ -1,0 +1,42 @@
+# ------------------------------------------------------------------------------------------------------------------
+# AWS Config - Recording Mode Configuration
+# ------------------------------------------------------------------------------------------------------------------
+# AWS Config is typically already enabled by Control Tower / AWS Organizations with CONTINUOUS
+# recording. This resource imports and manages the existing configuration recorder to switch
+# it to DAILY recording, which reduces costs while still maintaining compliance visibility.
+#
+# Prerequisites:
+# - AWS Config must already be enabled (e.g., by Control Tower)
+# ------------------------------------------------------------------------------------------------------------------
+
+data "aws_iam_role" "config_recorder" {
+  count = var.manage_aws_config_recording_mode && var.aws_config_recorder_role_arn == "" ? 1 : 0
+
+  name = var.aws_config_recorder_role_name
+}
+
+locals {
+  aws_config_role_arn = var.aws_config_recorder_role_arn != "" ? var.aws_config_recorder_role_arn : try(data.aws_iam_role.config_recorder[0].arn, "")
+}
+
+import {
+  for_each = var.manage_aws_config_recording_mode ? toset([var.aws_config_recorder_name]) : toset([])
+  to       = aws_config_configuration_recorder.this[0]
+  id       = each.value
+}
+
+resource "aws_config_configuration_recorder" "this" {
+  count = var.manage_aws_config_recording_mode ? 1 : 0
+
+  name     = var.aws_config_recorder_name
+  role_arn = local.aws_config_role_arn
+
+  recording_group {
+    all_supported                 = var.aws_config_recording_group.all_supported
+    include_global_resource_types = var.aws_config_recording_group.include_global_resource_types
+  }
+
+  recording_mode {
+    recording_frequency = var.aws_config_recording_frequency
+  }
+}

--- a/modules/region_level/outputs.tf
+++ b/modules/region_level/outputs.tf
@@ -17,3 +17,8 @@ output "access_logs_bucket_arn" {
   description = "The ARN of the S3 bucket used for storing Terraform state"
   value       = try(module.logs_bucket.s3_bucket_arn, "")
 }
+
+output "config_recorder_id" {
+  description = "The ID of the AWS Config configuration recorder"
+  value       = try(aws_config_configuration_recorder.this[0].id, "")
+}

--- a/modules/region_level/variables.tf
+++ b/modules/region_level/variables.tf
@@ -224,6 +224,56 @@ variable "create_ebs_encryption_by_default" {
 
 # ------------------------------------------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------------------------------------------
+# AWS Config - Recording Mode
+# AWS Config is already enabled by Control Tower. These variables allow managing the
+# recording frequency (switching from CONTINUOUS to DAILY).
+
+variable "manage_aws_config_recording_mode" {
+  description = "Whether to manage the AWS Config recorder's recording mode. Set to true to switch to daily recording."
+  type        = bool
+  default     = false
+}
+
+variable "aws_config_recorder_name" {
+  description = "The name of the existing AWS Config configuration recorder."
+  type        = string
+  default     = "default"
+}
+
+variable "aws_config_recorder_role_arn" {
+  description = "The ARN of the existing IAM role used by the AWS Config recorder. If empty, the module will look it up using `aws_config_recorder_role_name`."
+  type        = string
+  default     = ""
+}
+
+variable "aws_config_recorder_role_name" {
+  description = "The name of the existing IAM role used by the AWS Config recorder. Used for automatic lookup when `aws_config_recorder_role_arn` is not provided. Defaults to the Control Tower role name."
+  type        = string
+  default     = "aws-controltower-ConfigRecorderRole"
+}
+
+variable "aws_config_recording_frequency" {
+  description = "Recording frequency for the configuration recorder. Valid values: CONTINUOUS, DAILY."
+  type        = string
+  default     = "DAILY"
+
+  validation {
+    condition     = contains(["CONTINUOUS", "DAILY"], var.aws_config_recording_frequency)
+    error_message = "Recording frequency must be either CONTINUOUS or DAILY."
+  }
+}
+
+variable "aws_config_recording_group" {
+  description = "Recording group configuration for AWS Config."
+  type = object({
+    all_supported                 = optional(bool, true)
+    include_global_resource_types = optional(bool, false)
+  })
+  default = {}
+}
+
+# ------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------------------------------------
 
 variable "tags" {
   type        = map(string)


### PR DESCRIPTION
Manage the existing Config recorder (created by Control Tower) to switch from CONTINUOUS to DAILY recording. Uses an import block to adopt the recorder into state and a data source to auto-detect the IAM role ARN.