### PR TITLE
feat(region_level): add AWS Config daily recording mode support

### DIFF
--- a/.github/workflows/terraform_linting.yml
+++ b/.github/workflows/terraform_linting.yml
@@ -12,3 +12,16 @@ jobs:
         with:
             terraform-version: "1.7.0"
             aws-default-region: "eu-central-1"
+            tfsec-continue-on-error: true
+
+    trivy:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Run Trivy IaC scanner
+              uses: aquasecurity/trivy-action@master
+              with:
+                scan-type: 'config'
+                scan-ref: '.'
+                exit-code: '1'
+                severity: 'HIGH,CRITICAL'


### PR DESCRIPTION
- Add config.tf to manage existing Config recorder's recording frequency
- Auto-detect Control Tower IAM role via data source
- Use import block to adopt existing recorder into state (requires TF >= 1.7)
- Bump required_version to >= 1.7.0
- Replace deprecated tfsec with Trivy for security scanning
- Add AWS_CONFIG_DAILY_RECORDING.md documentation