### PR TITLE
feat(region_level): add AWS Config daily recording mode support

### DIFF
--- a/modules/region_level/AWS_CONFIG_DAILY_RECORDING.md
+++ b/modules/region_level/AWS_CONFIG_DAILY_RECORDING.md
@@ -18,9 +18,10 @@ module "baseline" {
 
 That's it. The module will:
 
-1. Automatically import the existing Config recorder (named `default`) into Terraform state
-2. Look up the existing IAM role (`aws-controltower-ConfigRecorderRole`) created by Control Tower
-3. Update the recording mode from `CONTINUOUS` to `DAILY`
+1. Look up the existing IAM role (`aws-controltower-ConfigRecorderRole`) created by Control Tower
+2. Update the recording mode from `CONTINUOUS` to `DAILY`
+
+**Note:** You must import the existing recorder into state on first use. See the "Importing the Existing Recorder" section below.
 
 ## Variables
 
@@ -35,9 +36,29 @@ That's it. The module will:
 
 ## How It Works
 
-- **Import block**: Uses Terraform's native `import` block (requires Terraform >= 1.5) to adopt the existing Config recorder into state on first apply. No manual `terraform import` command needed.
 - **Role detection**: Looks up the Control Tower-created IAM role by name via a `data "aws_iam_role"` data source. You can skip this by providing `aws_config_recorder_role_arn` directly.
 - **Idempotent**: If you deploy this to an account where Config is already set to DAILY, Terraform will show no changes.
+
+## Importing the Existing Recorder
+
+Since AWS Config is already running in your accounts, you need to import the existing recorder into Terraform state. Do this from the **root module** (your AFT customizations), not inside this module.
+
+**Option A** - Import block in your root module (Terraform >= 1.5):
+
+```hcl
+import {
+  to = module.baseline.aws_config_configuration_recorder.this[0]
+  id = "default"
+}
+```
+
+**Option B** - CLI import:
+
+```bash
+terraform import 'module.baseline.aws_config_configuration_recorder.this[0]' default
+```
+
+After the first successful apply, you can remove the import block — the resource will already be in state.
 
 ## Important Notes
 

--- a/modules/region_level/config.tf
+++ b/modules/region_level/config.tf
@@ -2,11 +2,13 @@
 # AWS Config - Recording Mode Configuration
 # ------------------------------------------------------------------------------------------------------------------
 # AWS Config is typically already enabled by Control Tower / AWS Organizations with CONTINUOUS
-# recording. This resource imports and manages the existing configuration recorder to switch
+# recording. This resource manages the existing configuration recorder to switch
 # it to DAILY recording, which reduces costs while still maintaining compliance visibility.
 #
 # Prerequisites:
 # - AWS Config must already be enabled (e.g., by Control Tower)
+# - The existing recorder must be imported into state from the root module:
+#   terraform import 'module.<name>.aws_config_configuration_recorder.this[0]' default
 # ------------------------------------------------------------------------------------------------------------------
 
 data "aws_iam_role" "config_recorder" {
@@ -17,12 +19,6 @@ data "aws_iam_role" "config_recorder" {
 
 locals {
   aws_config_role_arn = var.aws_config_recorder_role_arn != "" ? var.aws_config_recorder_role_arn : try(data.aws_iam_role.config_recorder[0].arn, "")
-}
-
-import {
-  for_each = var.manage_aws_config_recording_mode ? toset([var.aws_config_recorder_name]) : toset([])
-  to       = aws_config_configuration_recorder.this[0]
-  id       = each.value
 }
 
 resource "aws_config_configuration_recorder" "this" {

--- a/modules/region_level/versions.tf
+++ b/modules/region_level/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.7.0"
+  required_version = "~>1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
- Add config.tf to manage existing Config recorder's recording frequency
- Auto-detect Control Tower IAM role via data source
- Import must be done from root module (AFT uses TF 1.6 which doesn't support import blocks in child modules)
- Replace deprecated tfsec with Trivy via reusable workflow branch
- Add AWS_CONFIG_DAILY_RECORDING.md documentation